### PR TITLE
Use default version of tensorflow which ABEJA Platform specifies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
+abeja-sdk==0.2.10
 h5py
 pillow
-tensorflow==1.13.1
+# tensorflow==1.13.1
 # tensorflow-gpu==1.13.1
 keras==2.2.4


### PR DESCRIPTION
ライブラリの書き換えが手間なので、Platformのデフォルトのライブラリを利用することに。